### PR TITLE
Pass an emoty confOverlay to make sure CDH 4.3.0 hiveserver2 does not blow up

### DIFF
--- a/lib/rbhive/t_c_l_i_connection.rb
+++ b/lib/rbhive/t_c_l_i_connection.rb
@@ -119,16 +119,16 @@ module RBHive
     def create_table(schema)
       execute(schema.create_table_statement)
     end
-    
+
     def drop_table(name)
       name = name.name if name.is_a?(TableSchema)
       execute("DROP TABLE `#{name}`")
     end
-    
+
     def replace_columns(schema)
       execute(schema.replace_columns_statement)
     end
-    
+
     def add_columns(schema)
       execute(schema.add_columns_statement)
     end
@@ -164,7 +164,7 @@ module RBHive
     end
 
     def prepare_execute_statement(query)
-      ::Hive2::Thrift::TExecuteStatementReq.new( sessionHandle: self.session, statement: query.to_s )
+      ::Hive2::Thrift::TExecuteStatementReq.new( sessionHandle: self.session, statement: query.to_s, confOverlay: {} )
     end
 
     def prepare_fetch_results(handle, orientation=:first, rows=100)


### PR DESCRIPTION
There is an issue with using rbhive with CDH 4.3.0 and hiveserver2: https://issues.cloudera.org/browse/DISTRO-500. Basically, it is impossible to use rbhive with CDH 4.3.0 hiveserver2 deployments. They have fixed it now and are going to release the fix in the next CDH release, but until then it would be nice to still be able to use rbhive.

I've made this simple change to pass an empty hash for the confOverlay parameter instead of relying the default null value being interpreted by the server correctly.
