### PR TITLE
fix incomplete data read in sasl_client_transport

### DIFF
--- a/lib/thrift/sasl_client_transport.rb
+++ b/lib/thrift/sasl_client_transport.rb
@@ -81,6 +81,9 @@ module Thrift
     def reset_buffer!
       len, = @transport.read(PAYLOAD_LENGTH_BYTES).unpack('l>')
       @rbuf = @transport.read(len)
+      while @rbuf.size < len
+        @rbuf << @transport.read(len - @rbuf.size)
+      end
       @index = 0
     end
   end


### PR DESCRIPTION
Current sasl_client_transport will fail in reading big data chunk because of a bug in `reset_buffer!` method.

``` ruby
len, = @transport.read(PAYLOAD_LENGTH_BYTES).unpack('l>')
@rbuf = @transport.read(len)
```

when the expected data size (`len`) is large,
seems it may multiple times of `transport.read` to fetch all of the data.
