### PR TITLE
Moved thin as a development dependency

### DIFF
--- a/rbhive.gemspec
+++ b/rbhive.gemspec
@@ -12,13 +12,14 @@ Gem::Specification.new do |spec|
   spec.email = ["andy@forward.co.uk","kolobock@gmail.com", "developers@forward3d.com"]
   spec.homepage = %q{http://github.com/forward3d/rbhive}
   spec.license = "MIT"
-  
+
   spec.files = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
-  
+
   spec.add_dependency('thrift', '>= 0.9.0')
-  spec.add_dependency('thin', '~> 1.5.1')
   spec.add_dependency('json')
+
+  spec.add_development_dependency('thin', '~> 1.5.1')
 end


### PR DESCRIPTION
This should be a development dependency, as its not needed at runtime. In cases where someone is using Jruby they also may not be able to install or use rbhive. 

Installing thin (1.5.1)
Gem::Installer::ExtensionBuildError: ERROR: Failed to build gem native extension.

```
    /Users/trentalbrigh/.rvm/rubies/jruby-1.7.4/bin/jruby extconf.rb
```

NotImplementedError: C extension support is not enabled. Pass -Xcext.enabled=true to JRuby or set JRUBY_OPTS or modify .jrubyrc to enable.

   (root) at /Users/trentalbrigh/.rvm/rubies/jruby-1.7.4/lib/ruby/shared/mkmf.rb:8
  require at org/jruby/RubyKernel.java:1054
   (root) at /Users/trentalbrigh/.rvm/rubies/jruby-1.7.4/lib/ruby/shared/rubygems/custom_require.rb:1
   (root) at extconf.rb:1
