### PR TITLE
Fix SASL negotiation on JRuby

### DIFF
--- a/lib/thrift/sasl_client_transport.rb
+++ b/lib/thrift/sasl_client_transport.rb
@@ -70,7 +70,7 @@ module Thrift
       when NEGOTIATION_STATUS[:BAD], NEGOTIATION_STATUS[:ERROR]
         raise @transport.to_io.read(len)
       when NEGOTIATION_STATUS[:COMPLETE]
-        @challenge = @transport.to_io.read len
+        @challenge = ""
       when NEGOTIATION_STATUS[:OK]
         raise "Failed to complete challenge exchange: only NONE supported currently"
       end


### PR DESCRIPTION
On MRI, calling `read(0)` immediately returns an empty string. On JRuby, calling `read(0)` blocks forever. See issue https://github.com/jruby/jruby/issues/1637

Looking at the Java Thrift client, https://github.com/apache/thrift/blob/master/lib/java/src/org/apache/thrift/transport/TSaslTransport.java#L285  once negotiation status is complete we don't need to do anything else so this should be a safe change to make.
