### PR TITLE
Remove duplicate :bigint entry and return nil for NULL Hive values

### DIFF
--- a/lib/rbhive/t_c_l_i_schema_definition.rb
+++ b/lib/rbhive/t_c_l_i_schema_definition.rb
@@ -9,7 +9,6 @@ module RBHive
     TYPES = {
       :boolean  => :to_s,
       :string   => :to_s,
-      :bigint   => :to_i,
       :float    => :to_f,
       :double   => :to_f,
       :int      => :to_i,
@@ -67,6 +66,7 @@ module RBHive
 
     def coerce_column(column_name, value)
       type = column_type_map[column_name]
+      return nil if value.nil?
       return INFINITY if (type != :string && value == "Infinity")
       return NAN if (type != :string && value == "NaN")
       return coerce_complex_value(value) if type.to_s =~ /^array/


### PR DESCRIPTION
We must merge https://github.com/forward3d/rbhive/pull/22 in order to see the benefit of this change.

If the results from Hive are in their correct Ruby types, then the current code will call `conversion_method ? value.send(conversion_method) : value` to determine what value is returned to the result set. However, if value is nil, then calling the conversion_method on nil will create default values such as 0 and empty string.