### PR TITLE
Correct spelling of #to_separated_output

### DIFF
--- a/lib/rbhive/result_set.rb
+++ b/lib/rbhive/result_set.rb
@@ -4,30 +4,30 @@ module RBHive
       @schema = schema
       super(rows.map {|r| @schema.coerce_row(r) })
     end
-    
+
     def column_names
       @schema.column_names
     end
-    
+
     def column_type_map
       @schema.column_type_map
     end
-    
+
     def to_csv(out_file=nil)
-      to_seperated_output(",", out_file)
+      to_separated_output(",", out_file)
     end
-    
+
     def to_tsv(out_file=nil)
-      to_seperated_output("\t", out_file)
+      to_separated_output("\t", out_file)
     end
-    
+
     def as_arrays
       @as_arrays ||= self.map{ |r| @schema.coerce_row_to_array(r) }
     end
-    
+
     private
-    
-    def to_seperated_output(sep, out_file)
+
+    def to_separated_output(sep, out_file)
       rows = self.map { |r| @schema.coerce_row_to_array(r).join(sep) }
       sv = rows.join("\n")
       return sv if out_file.nil?


### PR DESCRIPTION
Corrected the spelling of seperated to separated for the method #to_separated_output on ResultSet. 