### PR TITLE
Added support for other storage formats

### DIFF
--- a/lib/rbhive/table_schema.rb
+++ b/lib/rbhive/table_schema.rb
@@ -8,6 +8,7 @@ module RBHive
       @field_sep = options[:field_sep] || "\t"
       @line_sep = options[:line_sep] || "\n"
       @collection_sep = options[:collection_sep] || "|"
+      @stored_as = options[:stored_as] || :textfile
       @columns = []
       @partitions = []
       @serde_name = nil
@@ -31,8 +32,12 @@ module RBHive
     def create_table_statement()
       %[CREATE #{external}TABLE #{table_statement}
   ROW FORMAT #{row_format_statement}
-  STORED AS TEXTFILE
+  STORED AS #{stored_as}
   #{location}]
+    end
+
+    def stored_as
+      @stored_as.to_s.upcase
     end
 
     def row_format_statement


### PR DESCRIPTION
Since Hive 0.11 it's possible to use other storage formats than text files (ORC, Parquet).
Previously the format was hardcoded, now it's possible to pass it as an extra option when calling TableSchema.new.