### PR TITLE
Adding tcli_connection options database

### DIFF
--- a/lib/rbhive/t_c_l_i_connection.rb
+++ b/lib/rbhive/t_c_l_i_connection.rb
@@ -54,6 +54,8 @@ module RBHive
     begin
       connection.open
       connection.open_session
+      options[:database] ||= 'default'
+      connection.execute("USE #{options[:database]}")
       ret = yield(connection)
 
     ensure


### PR DESCRIPTION
Thank you for this great library!

I wasn't able to specify the database name other than the default

I changed it in order to add database to option in tcli connection.

sample

```
RBHive.tcli_connect(hive.address,hive.port,{database: 'hogehuga'}) do |c|
  c.fetch 'show tables'
end
```

For this reason, I have sent a pull request.

Thank you.