### PR TITLE
Raise error when async_execute failed.

### DIFF
--- a/lib/rbhive/t_c_l_i_connection.rb
+++ b/lib/rbhive/t_c_l_i_connection.rb
@@ -192,14 +192,16 @@ module RBHive
     # Async execute
     def async_execute(query)
       @logger.info("Executing query asynchronously: #{query}")
-      op_handle = @client.ExecuteStatement(
+      exec_result = @client.ExecuteStatement(
         Hive2::Thrift::TExecuteStatementReq.new(
           sessionHandle: @session.sessionHandle,
           statement: query,
           runAsync: true
         )
-      ).operationHandle
-      
+      )
+      raise_error_if_failed!(exec_result)
+      op_handle = exec_result.operationHandle
+
       # Return handles to get hold of this query / session again
       {
         session: @session.sessionHandle, 

--- a/lib/rbhive/t_c_l_i_connection.rb
+++ b/lib/rbhive/t_c_l_i_connection.rb
@@ -238,7 +238,7 @@ module RBHive
       response = @client.GetOperationStatus(
         Hive2::Thrift::TGetOperationStatusReq.new(operationHandle: prepare_operation_handle(handles))
       )
-      puts response.operationState
+
       case response.operationState
       when Hive2::Thrift::TOperationState::FINISHED_STATE
         return :finished


### PR DESCRIPTION
I tried `async_execute`.
When invalid SQL is passed, `async_execute` does not raise an exception about Hive but NoMethodError.

```
[8] pry(main)> handles = connnection.async_execute("something wrong")                                       
Executing query asynchronously: something wrong
NoMethodError: undefined method `operationId' for nil:NilClass
from /home/ojima-h/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/rbhive-1.0.3.pre/lib/rbhive/t_c_l_i_connection.rb:206:in `async_execute'
```

So, I called `raise_error_if_failed` before retrieving `operationHandle`.

Thank you.