### PR TITLE
Add method to get error message from async handles

### DIFF
--- a/lib/rbhive/t_c_l_i_connection.rb
+++ b/lib/rbhive/t_c_l_i_connection.rb
@@ -260,7 +260,14 @@ module RBHive
         return :state_not_in_protocol
       end
     end
-        
+
+    def async_error_message(handles)
+      response = @client.GetOperationStatus(
+        Hive2::Thrift::TGetOperationStatusReq.new(operationHandle: prepare_operation_handle(handles))
+      )
+      response.errorMessage
+    end
+ 
     # Async fetch results from an async execute
     def async_fetch(handles, max_rows = 100)
       # Can't get data from an unfinished query


### PR DESCRIPTION
I could not find any method that read error message when async execution failed.

I added a method that returns `errorMessage` from GetOperationStatus response.
