### PR TITLE
Rename table and Role classes to not conflict with existing classes

### DIFF
--- a/lib/rbhive/version.rb
+++ b/lib/rbhive/version.rb
@@ -1,3 +1,3 @@
 module RBHive
-  VERSION = '1.0.3.pre'
+  VERSION = '1.0.3.brian'
 end

--- a/lib/thrift/hive_metastore_types.rb
+++ b/lib/thrift/hive_metastore_types.rb
@@ -201,7 +201,7 @@ class PrincipalPrivilegeSet
   ::Thrift::Struct.generate_accessors self
 end
 
-class Role
+class HiveRole
   include ::Thrift::Struct, ::Thrift::Struct_Union
   ROLENAME = 1
   CREATETIME = 2
@@ -317,7 +317,7 @@ class StorageDescriptor
   ::Thrift::Struct.generate_accessors self
 end
 
-class Table
+class HiveTable
   include ::Thrift::Struct, ::Thrift::Struct_Union
   TABLENAME = 1
   DBNAME = 2

--- a/lib/thrift/thrift_hive_metastore.rb
+++ b/lib/thrift/thrift_hive_metastore.rb
@@ -2119,7 +2119,7 @@ module ThriftHiveMetastore
     TBL = 1
 
     FIELDS = {
-      TBL => {:type => ::Thrift::Types::STRUCT, :name => 'tbl', :class => ::Table}
+      TBL => {:type => ::Thrift::Types::STRUCT, :name => 'tbl', :class => ::HiveTable}
     }
 
     def struct_fields; FIELDS; end
@@ -2285,7 +2285,7 @@ module ThriftHiveMetastore
     O2 = 2
 
     FIELDS = {
-      SUCCESS => {:type => ::Thrift::Types::STRUCT, :name => 'success', :class => ::Table},
+      SUCCESS => {:type => ::Thrift::Types::STRUCT, :name => 'success', :class => ::HiveTable},
       O1 => {:type => ::Thrift::Types::STRUCT, :name => 'o1', :class => ::MetaException},
       O2 => {:type => ::Thrift::Types::STRUCT, :name => 'o2', :class => ::NoSuchObjectException}
     }
@@ -2307,7 +2307,7 @@ module ThriftHiveMetastore
     FIELDS = {
       DBNAME => {:type => ::Thrift::Types::STRING, :name => 'dbname'},
       TBL_NAME => {:type => ::Thrift::Types::STRING, :name => 'tbl_name'},
-      NEW_TBL => {:type => ::Thrift::Types::STRUCT, :name => 'new_tbl', :class => ::Table}
+      NEW_TBL => {:type => ::Thrift::Types::STRUCT, :name => 'new_tbl', :class => ::HiveTable}
     }
 
     def struct_fields; FIELDS; end
@@ -3105,7 +3105,7 @@ module ThriftHiveMetastore
 
     FIELDS = {
       NEW_INDEX => {:type => ::Thrift::Types::STRUCT, :name => 'new_index', :class => ::Index},
-      INDEX_TABLE => {:type => ::Thrift::Types::STRUCT, :name => 'index_table', :class => ::Table}
+      INDEX_TABLE => {:type => ::Thrift::Types::STRUCT, :name => 'index_table', :class => ::HiveTable}
     }
 
     def struct_fields; FIELDS; end
@@ -3343,7 +3343,7 @@ module ThriftHiveMetastore
     ROLE = 1
 
     FIELDS = {
-      ROLE => {:type => ::Thrift::Types::STRUCT, :name => 'role', :class => ::Role}
+      ROLE => {:type => ::Thrift::Types::STRUCT, :name => 'role', :class => ::HiveRole}
     }
 
     def struct_fields; FIELDS; end
@@ -3557,7 +3557,7 @@ module ThriftHiveMetastore
     O1 = 1
 
     FIELDS = {
-      SUCCESS => {:type => ::Thrift::Types::LIST, :name => 'success', :element => {:type => ::Thrift::Types::STRUCT, :class => ::Role}},
+      SUCCESS => {:type => ::Thrift::Types::LIST, :name => 'success', :element => {:type => ::Thrift::Types::STRUCT, :class => ::HiveRole}},
       O1 => {:type => ::Thrift::Types::STRUCT, :name => 'o1', :class => ::MetaException}
     }
 


### PR DESCRIPTION
Made a few changes. Renamed some of the thrift classes to not conflict with my own classes. Looks like it may address issue #20 and #47. I've not done extensive testing on these changes, nor do I know if this may have any side effects. My simple select statement test case worked for me.