### PR TITLE
Custom ioformat support

### DIFF
--- a/lib/rbhive/table_schema.rb
+++ b/lib/rbhive/table_schema.rb
@@ -37,7 +37,11 @@ module RBHive
     end
 
     def stored_as
-      @stored_as.to_s.upcase
+      if @stored_as.is_a? String
+        @stored_as.to_s.upcase
+      else
+        "INPUTFORMAT #{@stored_as[:inputformat]} OUTPUTFORMAT #{@stored_as[:outputformat]}"
+      end
     end
 
     def row_format_statement

--- a/lib/rbhive/table_schema.rb
+++ b/lib/rbhive/table_schema.rb
@@ -40,7 +40,7 @@ module RBHive
       if @stored_as.is_a? String
         @stored_as.to_s.upcase
       else
-        "INPUTFORMAT #{@stored_as[:inputformat]} OUTPUTFORMAT #{@stored_as[:outputformat]}"
+        "INPUTFORMAT '#{@stored_as[:inputformat]}' OUTPUTFORMAT '#{@stored_as[:outputformat]}'"
       end
     end
 


### PR DESCRIPTION
Hive allows using custom input/outputformat as detailed in https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-StorageFormatsStorageFormatsRowFormat,StorageFormat,andSerDe

Would also like to document this, should I add a section in the README on how to specify serde?